### PR TITLE
deglobalize variables; protect stats map with sync.Mutex

### DIFF
--- a/matcher.go
+++ b/matcher.go
@@ -4,14 +4,14 @@ import (
 	"regexp"
 )
 
-var paths []*regexp.Regexp
+type matcher []*regexp.Regexp
 
-func MatchAnyRule(request ModifiedRequest) bool {
+func (m matcher) MatchAnyRule(request ModifiedRequest) bool {
 
 	if request.Path == "" {
 		return false
 	}
-	for _, matcher := range paths {
+	for _, matcher := range m {
 		if matcher.MatchString(request.Path) {
 			return true
 		}
@@ -19,13 +19,14 @@ func MatchAnyRule(request ModifiedRequest) bool {
 	return false
 }
 
-func AddMatcherRules(rules []string) error {
+func newMatcher(rules []string) (matcher, error) {
+	var m matcher
 	for _, p := range rules {
 		compiled, err := regexp.Compile(p)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		paths = append(paths, compiled)
+		m = append(m, compiled)
 	}
-	return nil
+	return m, nil
 }


### PR DESCRIPTION
This PR proposes:
- Deglobalizing some variables and attaching them to the proxy instance.
- Protecting the stats map with a mutex.
- Error handling tweaks.