### PR TITLE
fix log nil pointer; improve request/response logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ docker:
 
 # Proxy to the testnet node http://35.228.129.142/
 run:
-	docker run --rm -it -p 8545:8545 -v ${PWD}/config.toml:/proxy.toml gochain/rpc-proxy -url http://35.228.129.142/ -port 8545 -rpm 1000 -config /proxy.toml
+	docker run --rm -it -p 8545:8545 -v ${PWD}/config.toml:/proxy.toml gochain/rpc-proxy -url http://35.228.129.142/ -port 8545 -rpm 1000 -config /proxy.toml -verbose
 
 install:
 	go install


### PR DESCRIPTION
This PR fixes a nil pointer from an oversight in the logging code, and reorganizes things in order to better log response information in addition to request.